### PR TITLE
Eth request accounts+deprecated call cleanup

### DIFF
--- a/eth-sign-verify.js
+++ b/eth-sign-verify.js
@@ -1,7 +1,9 @@
-window.addEventListener('load', function () {
-    if (typeof web3 !== 'undefined') {
-        console.log('Web3 Detected! ' + web3.currentProvider.constructor.name)
-        window.web3 = new Web3(web3.currentProvider);
+window.addEventListener('load', async function () {
+    if (typeof window.ethereum !== 'undefined') {
+        console.log('Web3 Detected! ')
+        window.web3 = new Web3(window.ethereum);
+        await window.ethereum.request({ method: 'eth_requestAccounts' })
+        console.log('ChainID: ', +window.ethereum.chainId)
     } else {
         console.log('No Web3 Detected... please install Metamask')
         document.getElementById("metamask_warning").hidden = false

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
     crossorigin="anonymous"></script>
 
   <!-- Custom Javascript-->
-  <script src="web3.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/web3/1.3.6/web3.min.js" integrity="sha512-jMEcX0Bev3VsCrACqEM3BFZvAMFXJSuTsMu0SttkAdMjquip6p3Oty5bbXrfg4T8n4g5BQYkGKxzLsrSqQgLUQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="eth-sign-verify.js"></script>
 </body>
 


### PR DESCRIPTION
- Updated Web3 version to 1.3.6
- By default web does not connects with MetaMask, "eth_requestAccounts" call is added to connect
- Window.ethereum instead of web3.currentProvider